### PR TITLE
12345: API Clean Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,15 @@
-# React + TypeScript + Vite
+# React Dropdowns
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A small project demonstrating a possible React DropdownMenu component.
 
-Currently, two official plugins are available:
+Features:
+- Custom components can be passed to represent the options / placeholder / reset children of the dropdown
+- Bi-directional display (up or down)
+- Supports container styling (apply corner radius, optional drop shadow, padding, etc to the container wrapped around the entire menu)
+- Tab support / auto-expands on focus
+- Animated expand / collapse
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default {
-  // other rules...
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json'],
-    tsconfigRootDir: __dirname,
-  },
-}
-```
-
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+Todo:
+- Accessibility
+- Limit size of dropdown to viewport bounds (see the "drop up" example)
+- Support left/right directions

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,51 +1,159 @@
 import React from "react";
 
 import DropdownMenu, { DropdownMenuOptionViewModel } from "./components/molecules/DropdownMenu";
-
-type Direction = "up" | "down";
+import { useDropdownMenuController } from "./components/molecules/useDropdownMenuController";
 
 function App() {
 
-	const [isExpanded, setIsExpanded] = React.useState(false);
-	const [selectedOption, setSelectedOption] = React.useState<DropdownMenuOptionViewModel<Direction> | null>(null);
+	// Create some dropdown menu controllers to manage the visual state of our dropdowns
+	const dropdownOne = useDropdownMenuController();
+	const dropdownTwo = useDropdownMenuController();
+	const dropdownThree = useDropdownMenuController();
+	const dropdownFour = useDropdownMenuController();
 
-	const options: DropdownMenuOptionViewModel<Direction>[] = [
+	// Create some state to manage the options / selected option exposed in our dropdowns. We will share this state with all dropdowns.
+	const [selectedOption, setSelectedOption] = React.useState<DropdownMenuOptionViewModel<string> | null>(null);
+	const options: DropdownMenuOptionViewModel<string>[] = [
 		{
-			key: "up",
-			component: <div>Up</div>,
-			value: "up"
+			key: "1",
+			component: <div>One</div>,
+			value: "One"
 		},
 		{
-			key: "down",
-			component: <div>Down</div>,
-			value: "down"
-		}
+			key: "2",
+			component: <div>Two</div>,
+			value: "Two"
+		},
+		{
+			key: "3",
+			component: <div>Three</div>,
+			value: "Three"
+		},
+		{
+			key: "4",
+			component: <div>Four</div>,
+			value: "Four"
+		},
 	];
 
 	return (
-		<div className="flex flex-col items-center justify-center w-full h-full bg-gray-50">
-			<DropdownMenu
-				className='w-max'
-				direction={selectedOption?.value ?? "down"}
-				options={options}
-				selectedOption={selectedOption}
-				placeholderComponent={
-					<div>Select Direction</div>
-				}
-				resetComponent={
-					<div>Clear</div>
-				}
-				isExpanded={isExpanded}
-				onRequestExpand={() => {
-					setIsExpanded(true);
-				}}
-				onRequestCollapse={() => {
-					setIsExpanded(false);
-				}}
-				onSelectOption={(option) => {
-					setSelectedOption(option);
-				}}
-			/>
+		<div className="flex flex-col w-full h-full gap-8 p-4 bg-gray-50">
+			{ /* Heading */ }
+			<div className="flex flex-col gap-2">
+				<h1 className="text-2xl">Dropdowns</h1>
+				<p><b>Selection: </b>{`${selectedOption?.value ?? 'None'}`}</p>
+			</div>
+			<div className="flex flex-row gap-4">
+				{ /* A custom dropdown menu */ }
+				<div className="flex flex-col gap-4">
+					<p>A custom dropdown</p>
+					<DropdownMenu
+						className='w-96'
+						direction={"down"}
+						options={options}
+						selectedOption={selectedOption}
+						placeholderComponent={
+							<div>Select Option</div>
+						}
+						resetComponent={
+							<div>Clear</div>
+						}
+						onSelectOption={(option) => {
+							setSelectedOption(option);
+						}}
+						isExpanded={dropdownOne.isExpanded}
+						onRequestExpand={() => {
+							dropdownOne.expand();
+						}}
+						onRequestCollapse={(reason) => {
+							dropdownOne.collapse(reason);
+						}}
+					/>
+				</div>
+
+				{ /* A custom dropdown menu */ }
+				<div className="flex flex-col gap-4">
+					<p>A fixed-height dropdown</p>
+					<DropdownMenu
+						className='w-96 max-h-48'
+						direction={"down"}
+						options={options}
+						selectedOption={selectedOption}
+						placeholderComponent={
+							<div>Select Option</div>
+						}
+						resetComponent={
+							<div>Clear</div>
+						}
+						onSelectOption={(option) => {
+							setSelectedOption(option);
+						}}
+						isExpanded={dropdownTwo.isExpanded}
+						onRequestExpand={() => {
+							dropdownTwo.expand();
+						}}
+						onRequestCollapse={(reason) => {
+							dropdownTwo.collapse(reason);
+						}}
+					/>
+				</div>
+
+				{ /* A custom dropdown menu */ }
+				<div className="flex flex-col gap-4">
+					<p>An auto-width dropdown</p>
+					<DropdownMenu
+						className='w-max'
+						direction={"down"}
+						options={options}
+						selectedOption={selectedOption}
+						placeholderComponent={
+							<div>Select Option</div>
+						}
+						resetComponent={
+							<div>Clear</div>
+						}
+						onSelectOption={(option) => {
+							setSelectedOption(option);
+						}}
+						isExpanded={dropdownThree.isExpanded}
+						onRequestExpand={() => {
+							dropdownThree.expand();
+						}}
+						onRequestCollapse={(reason) => {
+							dropdownThree.collapse(reason);
+						}}
+					/>
+				</div>
+
+				{ /* A custom dropdown menu */ }
+				<div className="flex flex-col gap-4">
+					<p>A drop-"up"</p>
+					<DropdownMenu
+						className='w-48'
+						direction={"up"}
+						options={options}
+						selectedOption={selectedOption}
+						placeholderComponent={
+							<div>Select Option</div>
+						}
+						resetComponent={
+							<div>Clear</div>
+						}
+						onSelectOption={(option) => {
+							setSelectedOption(option);
+						}}
+						isExpanded={dropdownFour.isExpanded}
+						onRequestExpand={() => {
+							dropdownFour.expand();
+						}}
+						onRequestCollapse={(reason) => {
+							dropdownFour.collapse(reason);
+						}}
+					/>
+				</div>
+				
+				
+			</div>
 		</div>
 	)
 }

--- a/src/components/molecules/DropdownMenuWrapperButton.tsx
+++ b/src/components/molecules/DropdownMenuWrapperButton.tsx
@@ -1,22 +1,20 @@
 interface DropdownMenuWrapperButtonProps {
 	className?: string;
-	onClick?: () => void;
 	children?: React.ReactNode;
+	onClick?: () => void;
+	onFocus?: () => void;
 }
 
+/**
+ * The button component that wraps each component rendered in a DropdownMenu.
+ */
 function DropdownMenuWrapperButton(props: DropdownMenuWrapperButtonProps) {
 
-	const { className, onClick } = props;
-
-	const handleClick = () => {
-		if (onClick) {
-			onClick();
-		}
-	}
+	const { className, onClick, onFocus } = props;
 
 	return (
-		<button onClick={handleClick} className={`
-			p-4 transition-all duration-300 hover:bg-slate-700 bg-slate-800 text-white
+		<button onClick={onClick} onFocus={onFocus} className={`
+			p-4 transition-all duration-300 hover:bg-slate-700 bg-slate-800 text-white border-t border-slate-700 outline-none focus:bg-slate-500 active:bg-slate-500
 			${className}
 		`}>
 			{ props.children }

--- a/src/components/molecules/useDropdownMenuController.ts
+++ b/src/components/molecules/useDropdownMenuController.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { DropdownMenuCollapseRequestReason } from "./DropdownMenu";
+
+/**
+ * A hook that provides the state and methods to control a dropdown menu.
+ * @returns An object containing the state and methods to control a dropdown menu.
+ */
+const useDropdownMenuController = () => {
+	
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	const handleRequestExpand = () => {
+		setIsExpanded(true);
+	}
+
+	/* eslint-disable @typescript-eslint/no-unused-vars */
+	const handleRequestCollapse = (reason: DropdownMenuCollapseRequestReason) => {
+		setIsExpanded(false);
+	}
+
+	return {
+		isExpanded,
+		expand: handleRequestExpand,
+		collapse: handleRequestCollapse,
+	}
+
+}
+
+export {
+	useDropdownMenuController
+}


### PR DESCRIPTION
**Ticket:**
- N/A

**In This PR:**
- Creating useDropdownMenuController hook for quickly setting up expansion state
- Collapsing dropdown when clicking outside of component
- Expanding dropdown when focus is tabbed to one of the inner buttons
- Adding documentation
- Adding 4 examples to App.tsx
- Updating Readme

**Screenshots:**

<img width="1245" alt="image" src="https://github.com/AdamEisfeld/react-dropdown/assets/2840242/52076d36-5e22-489f-bb87-95b831fc448d">

<img width="1244" alt="image" src="https://github.com/AdamEisfeld/react-dropdown/assets/2840242/83640f8a-1b0e-4b1b-913f-7e1a756318f7">

<img width="1249" alt="image" src="https://github.com/AdamEisfeld/react-dropdown/assets/2840242/60ebc388-aeed-4f80-b0f5-4840dfd3dc7f">

<img width="1250" alt="image" src="https://github.com/AdamEisfeld/react-dropdown/assets/2840242/4143168c-deab-478e-862a-c47ce28479d2">
